### PR TITLE
feat: create default gitea organization kdl

### DIFF
--- a/helm/science-toolkit/templates/gitea/init-configmap.yaml
+++ b/helm/science-toolkit/templates/gitea/init-configmap.yaml
@@ -108,6 +108,12 @@ data:
           --config /data/gitea/conf/app.ini \
           --admin >> /data/gitea/create_user.log
         echo "User created"
+        curl -v -X POST "http://localhost:3000/api/v1/admin/users/toolkit-admin/orgs" \
+          -u {{ .Values.gitea.admin.username }}:{{ .Values.gitea.admin.password }} \
+          -H "Content-Type: application/json" \
+          -H  "accept: application/json" \
+          --data '{"username": "kdl"}'
+        echo "Organization KDL created"
         exit 0
       elif [ "$API_RESPONSE_CODE" == "200"  ]; then
        echo "User exist"


### PR DESCRIPTION
When Science Toolkit is deployed a default `kdl` organization should be configured to host all the repositories that well be created via the kdl-server automatization